### PR TITLE
liam.is-a.bot

### DIFF
--- a/domains/_vercel.liam.json
+++ b/domains/_vercel.liam.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "liamatienza",
+        "email": "liamdev@duck.com"
+    },
+    "records": {
+        "TXT": "vc-domain-verify=liam.is-a.bot,5bb52da078c2c03e0e72"
+    }
+}

--- a/domains/liam.json
+++ b/domains/liam.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "liamatienza",
+    "email": "liamdev@duck.com"
+  },
+  "records": {
+    "CNAME": "a30ed0bcc944a709.vercel-dns-017.com"
+  }
+}


### PR DESCRIPTION
<!--
YOU MUST FILL OUT THIS TEMPLATE FOR YOUR PR TO BE ACCEPTED!
FAILURE TO COMPLETE ALL REQUIREMENTS WILL RESULT IN A DENIAL OF YOUR PR!
-->

# Requirements
<!-- Your domain MUST pass ALL the requirements below, otherwise it WILL BE DENIED. -->
<!-- Change each checkbox to [x] (all lowercase, with no spaces between the brackets) to mark it as completed. -->

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms). <!-- Your request MUST follow the TOS to be approved. NOTE: We do permit Discord bots, AI chatbots, etc. on is-a.bot subdomains. -->
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/). <!-- Your file is in the domains directory, the name is valid, it is JSON format, etc. -->
- [x] My website is **reachable** and **completed**. <!-- We do not permit simple "Hello, world!" or simply copied template websites with minimal changes. -->
- [ ] My website is **bot** related. <!-- We do not accept websites such as gaming, courses, portfolios, etc. NOTE: Only your root subdomain needs to meet this requirement. -->
- [x] My website is **not for commercial use**. <!-- Your website's purpose should not be to generate any form of revenue or profit. (e.g. a business) -->
- [x] I have provided sufficient contact information in the `owner` key. <!-- Provide your email in the `email` field or another platform (e.g. Twitter or Discord) for contact. -->
- [x] I have provided a link to my website below. <!-- This step is required for your PR to be approved. -->

# Website Preview
<!-- Provide a link of your website below. We do NOT accept screenshots, with the exception we ask you for one. -->
<!-- This should be a link to the existing domain your website is on, NOT the is-a.dev domain you're applying for. (e.g. abc.vercel.app, abc.github.io) -->
<!-- SCREENSHOTS ARE NOT PERMITTED AS PREVIEWS. -->
https://liam.is-a.dev/

# Website Purpose
<!-- Please tell us the purpose or motive behind your website. For example, it is a bot dashboard, etc. -->
Portfolio