### PR TITLE
Add Resend email sending records for princedotdev.is-a.bot

### DIFF
--- a/domains/brevo1._domainkey.princedotdev.json
+++ b/domains/brevo1._domainkey.princedotdev.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "10xdev4u-alt",
+        "email": "10xdev4u@gmail.com"
+    },
+    "records": {
+        "CNAME": "b1.princedotdev-is-a-bot.dkim.brevo.com"
+    }
+}

--- a/domains/brevo2._domainkey.princedotdev.json
+++ b/domains/brevo2._domainkey.princedotdev.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "10xdev4u-alt",
+        "email": "10xdev4u@gmail.com"
+    },
+    "records": {
+        "CNAME": "b2.princedotdev-is-a-bot.dkim.brevo.com"
+    }
+}

--- a/domains/princedotdev.json
+++ b/domains/princedotdev.json
@@ -5,6 +5,10 @@
     },
     "records": {
         "MX": ["mx1.improvmx.com", "mx2.improvmx.com"],
-        "TXT": ["v=spf1 include:spf.improvmx.com ~all"]
+        "TXT": [
+            "v=spf1 include:spf.improvmx.com ~all",
+            "brevo-code:6e0e07320189d975180f826cb4796131",
+            "v=DMARC1; p=none; rua=mailto:rua@dmarc.brevo.com"
+        ]
     }
 }

--- a/domains/resend._domainkey.princedotdev.json
+++ b/domains/resend._domainkey.princedotdev.json
@@ -1,0 +1,9 @@
+{
+    "owner": {
+        "username": "10xdev4u-alt",
+        "email": "10xdev4u@gmail.com"
+    },
+    "records": {
+        "TXT": "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDMb4hTp5Jyw6Oh/k3rNTMIzIrvu2g+ICZis+Lhq2aQCHgDVGcYZGzITabBeyj9uG+Bb2re4bMpbOA886kn6mqb1c9IcCJv5rSNNJmkqFeDHvNZEOqe4wI2SIpRM9je5FgWvNVqTjMPM0eYs9yLHfR7EjeFqnYrGgT4Y7J4gFpzTQIDAQAB"
+    }
+}

--- a/domains/send.princedotdev.json
+++ b/domains/send.princedotdev.json
@@ -1,0 +1,10 @@
+{
+    "owner": {
+        "username": "10xdev4u-alt",
+        "email": "10xdev4u@gmail.com"
+    },
+    "records": {
+        "MX": ["feedback-smtp.ap-northeast-1.amazonses.com"],
+        "TXT": "v=spf1 include:amazonses.com ~all"
+    }
+}


### PR DESCRIPTION
## Summary
Add Resend email sending records for princedotdev.is-a.bot

## Changes

| File | Records |
|------|---------|
| `send.princedotdev.json` | MX (Amazon SES) + SPF (include:amazonses.com) |
| `resend._domainkey.princedotdev.json` | DKIM TXT record |

## Why?
- Brevo DKIM verification was stuck on mismatch for 4+ days
- Resend provides reliable email sending with 100 emails/day free
- Uses subdomain `send.princedotdev` — **no conflict** with existing ImprovMX root domain MX records

## Setup
- Region: ap-northeast-1 (Tokyo) — optimal for India
- SMTP: `smtp.resend.com` port `587`
- Username: `resend`
- Password: API key

CC: @maintainers