### PR TITLE
Add Vercel verification for billy.is-a.bot

### DIFF
--- a/domains/_vercel.billy.json
+++ b/domains/_vercel.billy.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "256javy",
+    "email": "256jv@proton.me"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=billy.is-a.bot,1aba91bf6a636f2a3089"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **bot** related.
- [x] My website is **not for commercial use**.
- [x] I have provided sufficient contact information in the `owner` key.
- [x] I have provided a link to my website below.

# Website Preview

https://billy-web.vercel.app

# Website Purpose

This adds the Vercel TXT ownership-verification record for `billy.is-a.bot`, whose registration was approved in #48.

Billy is a Telegram bot (`@billy_the_bills_bot`) that receives personal invoices and receipts, extracts their data with AI, and lets the user browse their own expenses. The site is a personal, non-commercial project with no paid plans, ads, or revenue.