### PR TITLE
Create _github-pages-challenge-nassreddine-net.morocco-projects.json

### DIFF
--- a/domains/_github-pages-challenge-nassreddine-net.morocco-projects.json
+++ b/domains/_github-pages-challenge-nassreddine-net.morocco-projects.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "NASSREDDINE-net",
+    "email": "nassreddineelmakhlouq@gmail.com"
+  },
+  "records": {
+    "TXT": "e009e71e62e61db56685bd9a7ef9af"
+  }
+}


### PR DESCRIPTION

Requirements :

- [x] I agree to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is reachable and completed.
- [x] My website is software development related.
- [x] My website is not for commercial use.
- [x] I have provided contact information in the owner key.
- [x] I have provided a preview of my website below.


 Website Preview

https://nassreddine.is-a.dev/morocco-projects-map/

https://github.com/NASSREDDINE-net/morocco-projects-map

Website Purpose

An interactive map for discovering and exploring projects across Morocco, including project locations, descriptions, and related information.

Domain

`morocco-projects.is-a.bot`

The subdomain points to the GitHub Pages deployment of the Morocco Projects Map.

Repository:

`NASSREDDINE-net/morocco-projects-map`

The project is a public interactive map built with Leaflet and OpenStreetMap.

Thank you for reviewing this request.

GitHub Pages Domain Verification

This Pull Request adds the TXT verification record required by GitHub Pages to verify ownership of:


`morocco-projects.is-a.bot`

Domain
https://github.com/NASSREDDINE-net/morocco-projects-map
`morocco-projects.is-a.bot`

Verification Record

The TXT value was generated by GitHub Pages specifically for this domain:

```text
e009e71e62e61db56685bd9a7ef9af

I reviewed PR #73 and found that the correct file was present initially:

_github-pages-challenge-NASSREDDINE-net.morocco-projects.json

It was then mistakenly renamed to:

_github-pages-challenge-nassreddinee-net.morocco-projects.json ❌

This is why GitHub cannot find the correct TXT file.
