### PR TITLE
add boris.is-a.bot

### DIFF
--- a/domains/boris.json
+++ b/domains/boris.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "borismilner",
+    "email": "boris.milner@gmail.com"
+  },
+  "records": {
+    "CNAME": "borismilner.github.io"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **not for commercial use**.
- [x] I have provided sufficient contact information in the `owner` key.
- [x] I have provided a link to my website below.

# Website Preview

https://borismilner.github.io/

# Website Purpose

My personal site. It indexes the open-source developer tools I write and maintain,
among them grabbit, AgentBox and snapper, with a short description of what each one
is for.

AgentBox is the reason `.is-a.bot` fits: it is a desktop notifier that lets coding
agents ask me something or interrupt me while I am away from the terminal, so a
short address on this zone reads better for it than the github.io one does.

Nothing on the site is for sale. There is no signup and no payment path anywhere on
it.
