### PR TITLE
Add bool‑hybrid‑array.is‑a.bot for open‑source Python library docs

### DIFF
--- a/domains/bool-hybrid-array.json
+++ b/domains/bool-hybrid-array.json
@@ -3,7 +3,7 @@
     "username": "Bksell",
     "email": "1289270215@qq.com"
   },
-  "record": {
+  "records": {
     "CNAME": "bksell.github.io"
   }
 }

--- a/domains/bool-hybrid-array.json
+++ b/domains/bool-hybrid-array.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "Bksell",
+    "email": "1289270215@qq.com"
+  },
+  "record": {
+    "CNAME": "bksell.github.io"
+  }
+}

--- a/domains/bool‑hybrid‑array.json
+++ b/domains/bool‑hybrid‑array.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "Bksell",
+    "email": "1289270215@qq.com"
+  },
+  "records": {
+    "CNAME": "bksell.github.io"
+  }
+}

--- a/domains/bool‑hybrid‑array.json
+++ b/domains/bool‑hybrid‑array.json
@@ -3,7 +3,7 @@
     "username": "Bksell",
     "email": "1289270215@qq.com"
   },
-  "records": {
+  "record": {
     "CNAME": "bksell.github.io"
   }
 }

--- a/domains/bool‑hybrid‑array.json
+++ b/domains/bool‑hybrid‑array.json
@@ -1,9 +1,0 @@
-{
-  "owner": {
-    "username": "Bksell",
-    "email": "1289270215@qq.com"
-  },
-  "record": {
-    "CNAME": "bksell.github.io"
-  }
-}


### PR DESCRIPTION
## Requirements
- [x] I have **read** and **agree** to the [Terms of Service](https://is-a.bot/terms).
- [x] My file is following the [domain structure](https://docs.is-a.bot/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **software development** related.
- [x] I have provided sufficient contact information in the `owner` key.
- [x] I have provided a preview of my website below.

## Website Preview
https://bksell.github.io/bool-hybrid-array/

## Website Purpose
Documentation site for bool-hybrid-array, an open-source Python boolean hybrid-array library.

Hello maintainers,

I'm applying for subdomain bool-hybrid-array.is‑a.bot.

bool-hybrid-array is an open-source Python boolean hybrid-array library.
‑ Repo: https://github.com/BKsell/bool-hybrid-array
‑ PyPI: https://pypi.org/project/bool-hybrid-array/
‑ Live docs: https://bksell.github.io/bool-hybrid-array/

DNS: CNAME pointing to bksell.github.io.
Non‑commercial open‑source project.

Thanks a lot for your spare‑time reviewing and maintaining this service.
I'll keep this site available and follow project rules.
