### PR TITLE
Add GitHub Pages verification TXT record for sagebrush

### DIFF
--- a/domains/_github-pages-challenge-jamesmoore1998.sagebrush.json
+++ b/domains/_github-pages-challenge-jamesmoore1998.sagebrush.json
@@ -1,0 +1,8 @@
+{
+    "owner": {
+        "username": "JamesMoore1998"
+    },
+    "records": {
+        "TXT": "4f076669b6d3b1a8fbf25a220aeee9"
+    }
+}


### PR DESCRIPTION
Adds the `_github-pages-challenge-jamesmoore1998.sagebrush` TXT record GitHub requires to verify ownership of `sagebrush.is-a.bot` for GitHub Pages custom domain use.