### PR TITLE
Add GitHub Pages verification TXT for kmc

### DIFF
--- a/domains/_github-pages-challenge-kmcbest.kmc.json
+++ b/domains/_github-pages-challenge-kmcbest.kmc.json
@@ -1,0 +1,9 @@
+﻿{
+    "owner": {
+        "username": "kmcbest",
+        "email": "kmc.best@gmail.com"
+    },
+    "records": {
+        "TXT": "4362e974854aa6f5727c11e2ec82b7"
+    }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **not for commercial use**.
- [x] I have provided sufficient contact information in the `owner` key.
- [x] I have provided a link to my website below.

# Website Preview
https://kmcbest.github.io

# Website Purpose
Add GitHub Pages verification TXT record for kmc.is-a.bot.