### PR TITLE
Register neobrowser.is-a.bot

### DIFF
--- a/domains/neobrowser.json
+++ b/domains/neobrowser.json
@@ -1,0 +1,10 @@
+{
+  "description": "NeoBrowser — an open-source MCP server that drives real Chrome with real logged-in sessions",
+  "owner": {
+    "username": "pitiflautico",
+    "email": "pitiflautico3@gmail.com"
+  },
+  "records": {
+    "CNAME": "pitiflautico.github.io"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **not for commercial use**.
- [x] I have provided sufficient contact information in the `owner` key.
- [x] I have provided a link to my website below.

# Website Preview

https://pitiflautico.github.io/neobrowser/

# Website Purpose

NeoBrowser is an open-source MCP server that drives the user's real Google Chrome via the Chrome DevTools Protocol. The landing page hosts the project docs, install instructions, and a live tool reference. The site is static, MIT-licensed, and has no ads or paid gates.