### PR TITLE
Register boteco.is-a.bot

### DIFF
--- a/domains/boteco.json
+++ b/domains/boteco.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "VariaVitrine",
+    "email": "VariaVitrine@users.noreply.github.com"
+  },
+  "records": {
+    "CNAME": "variavitrine.github.io"
+  }
+}


### PR DESCRIPTION
## Registering `boteco` subdomain

**BOTECO** - a Brazilian local-first AI agent platform (bring-your-own-key agents, QR pairing, routines, 100% PT-BR).

- **Record requested:** CNAME `boteco` -> `variavitrine.github.io` (GitHub Pages)
- **Live site:** https://variavitrine.github.io/boteco/ (HTTP 200)
- **Public repo:** https://github.com/VariaVitrine/boteco
- **Owner JSON:** owner.username = VariaVitrine (noreply email used for privacy)

Thanks for the free service!