### PR TITLE
Add GitHub Pages verification for aidaily.is-a.bot

### DIFF
--- a/domains/_github-pages-challenge-himanshuramavat07.aidaily.json
+++ b/domains/_github-pages-challenge-himanshuramavat07.aidaily.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "himanshuramavat07",
+    "email": "himanshu.nitsan@gmail.com"
+  },
+  "records": {
+    "TXT": "aec6b0d3607a7964afa9242eca94c9"
+  }
+}


### PR DESCRIPTION
Adds GitHub Pages domain verification TXT record for aidaily.is-a.bot.

- Hostname: _github-pages-challenge-HimanshuRamavat07.aidaily.is-a.bot
- Root domain `aidaily.json` already merged
- GitHub username: HimanshuRamavat07