### PR TITLE
Add pair-nixie.json for domain configuration

### DIFF
--- a/domains/pair-nixie.json
+++ b/domains/pair-nixie.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "HarryPotter-coder79"
+  },
+  "records": {
+    "CNAME": "bfc098c12d372820.vercel-dns-017.com"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **not for commercial use**.
- [x] I have provided sufficient contact information in the `owner` key.
- [x] I have provided a link to my website below.

# Website Preview

https://pair-nixie.vercel.app/

# Website Purpose


NIXIE is a WhatsApp bot pairing website. It allows users to connect their WhatsApp account to the NIXIE bot through a pairing interface and provides the necessary connection and pairing functionality.