### PR TITLE
feat: add pretend.is-a.bot and _vercel verification record

### DIFF
--- a/domains/_vercel.pretend.json
+++ b/domains/_vercel.pretend.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "MKishoreDev",
+    "email": "kishoredxd@gmail.com"
+  },
+  "records": {
+    "TXT": "vc-domain-verify=pretend.is-a.bot,fdcf3d31b120a36ac261"
+  }
+}

--- a/domains/pretend.json
+++ b/domains/pretend.json
@@ -1,0 +1,9 @@
+{
+  "owner": {
+    "username": "MKishoreDev",
+    "email": "kishoredxd@gmail.com"
+  },
+  "records": {
+    "CNAME": "3a3fd8e394fa46b1.vercel-dns-017.com"
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **not for commercial use**.
- [x] I have provided sufficient contact information in the `owner` key.
- [x] I have provided a link to my website below.

# Website Preview

https://pretendai.vercel.app

# Website Purpose

PretendAI is an interactive Reverse Turing Test game where AI pretends to be human and humans pretend to be AI. It includes daily trending AI character challenges, custom AI archetypes, and 1v1 guessing games.