### PR TITLE
Register kaeduas.is-a.bot for personal developer portfolio

### DIFF
--- a/domains/kaeduas.json
+++ b/domains/kaeduas.json
@@ -1,0 +1,19 @@
+{
+  "description": "Personal developer portfolio of Qophe Junior Motsamai (QJ) — generative video experiments, open-source tools, and a culture quiz on SA entertainment and creative craft.",
+  "repo": "https://github.com/QJMotsamai/kaeduas",
+  "owner": {
+    "username": "QJMotsamai",
+    "email": "motsamai.main@gmail.com"
+  },
+  "records": {
+    "CNAME": "qjmotsamai.github.io",
+    "MX": [
+      "mx1.improvmx.com",
+      "mx2.improvmx.com"
+    ],
+    "TXT": [
+      "v=spf1 include:spf.improvmx.com ~all"
+    ]
+  },
+  "proxied": true
+}


### PR DESCRIPTION
# Requirements

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **not for commercial use**.
- [x] I have provided sufficient contact information in the `owner` key.
- [x] I have provided a link to my website below.

# Website Preview

https://qjmotsamai.github.io/kaeduas/

# Website Purpose

Personal developer portfolio for **Qophe Junior Motsamai (QJ)**.

The site is a completed personal portfolio / developer showcase: generative-video experiments, open-source tools (research agent, chatbot demos), and an interactive culture quiz on South African entertainment and creative craft. It is not a store, not a checkout, and is not used to sell products or run paid client campaigns through this subdomain.

DNS in `domains/kaeduas.json`:
- `CNAME` → `qjmotsamai.github.io` (GitHub Pages)
- `MX` + SPF via ImprovMX for personal email forwarding
- `proxied: true` so CNAME (ALIAS) and MX can coexist