### PR TITLE
Register rtmanager.is-a.bot

### DIFF
--- a/domains/rtmanager.json
+++ b/domains/rtmanager.json
@@ -1,0 +1,8 @@
+{
+  "owner": {
+    "username": "yashejit"
+  },
+  "records": {
+    "A": ["89.35.131.127"]
+  }
+}


### PR DESCRIPTION
Retry of #314 — added a public landing page so the link shows real content instead of an immediate Discord OAuth redirect (that was the reason #314 got closed as "incomplete website").

- [x] I **agree** to the [Terms of Service](https://is-a.dev/terms).
- [x] My file is following the [domain structure](https://docs.is-a.dev/domain-structure/).
- [x] My website is **reachable** and **completed**.
- [x] My website is **not for commercial use**.
- [x] I have provided sufficient contact information in the `owner` key.
- [x] I have provided a link to my website below.

# Website Preview
https://89.35.131.127/ (self-signed cert for now, will switch to a Let's Encrypt cert on this domain once it's live). Visiting it now shows a landing page describing the tool with a "Log in with Discord" button, instead of redirecting straight into the OAuth flow.

# Website Purpose
RTManager — a private Discord bot dashboard for managing a World of Warcraft guild: creating/editing raid events with RSVP buttons, a character/roster manager, and a calendar view. Access past the landing page is gated behind Discord OAuth login and restricted to members of the guild's own Discord server.